### PR TITLE
Modify docker-compose.yml and add VS Code workspace file to point sandbox image to hspconsortium/sandbox-manager-v3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ volumes:
   logica-sandbox-volume:
 
 services:
-
   keycloak:
     image: jboss/keycloak
     volumes:
@@ -15,7 +14,11 @@ services:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=admin
       - KEYCLOAK_IMPORT=/etc/security/realm_properties.json
-    command: ["-Djboss.http.port=8080", "-Dkeycloak.profile.feature.upload_scripts=enabled"]
+    command:
+      [
+        "-Djboss.http.port=8080",
+        "-Dkeycloak.profile.feature.upload_scripts=enabled",
+      ]
 
   sandbox-mysql:
     image: logicahealth/sandbox-mysql
@@ -53,7 +56,9 @@ services:
         condition: service_healthy
 
   sandbox:
-    image: logicahealth/sandbox:latest
+    build:
+      context: ../sandbox-manager-v3
+      dockerfile: Dockerfile.dev
     ports:
       - "3000:3000"
       - "3001:3001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   logica-sandbox-volume:
 
 services:
+
   keycloak:
     image: jboss/keycloak
     volumes:
@@ -14,11 +15,7 @@ services:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=admin
       - KEYCLOAK_IMPORT=/etc/security/realm_properties.json
-    command:
-      [
-        "-Djboss.http.port=8080",
-        "-Dkeycloak.profile.feature.upload_scripts=enabled",
-      ]
+    command: ["-Djboss.http.port=8080", "-Dkeycloak.profile.feature.upload_scripts=enabled"]
 
   sandbox-mysql:
     image: logicahealth/sandbox-mysql
@@ -56,9 +53,10 @@ services:
         condition: service_healthy
 
   sandbox:
-    build:
-      context: ../sandbox-manager-v3
-      dockerfile: Dockerfile.dev
+    # sandbox:latest is built on 3.4.7, not latest from sandbox-manager-v3 which is 3.4.9
+    image: logicahealth/sandbox:latest
+    volumes:
+      - ../sandbox-manager-v3/projects/sandbox-manager/src/redux/action-creators/hooks.js:/projects/sandbox-manager/src/redux/action-creators/hooks.js
     ports:
       - "3000:3000"
       - "3001:3001"

--- a/sandbox-community-edition.code-workspace
+++ b/sandbox-community-edition.code-workspace
@@ -1,11 +1,14 @@
 {
-	"folders": [
-		{
-			"path": "."
-		},
-		{
-			"path": "../sandbox-manager-v3"
-		}
-	],
-	"settings": {}
+  "folders": [
+    {
+      "path": "."
+    },
+    {
+      "path": "../sandbox-manager-v3"
+    },
+    {
+      "path": "../sandbox-manager-ui"
+    }
+  ],
+  "settings": {}
 }

--- a/sandbox-community-edition.code-workspace
+++ b/sandbox-community-edition.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "../sandbox-manager-v3"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
Not intended for directly merging to `logicahealth: main`. 
Actually not fixed. Current error is a 500 error when grabbing the order-select.

Sandbox image points to a fork of hspconsortium/sandbox-manager-v3, on specific branch https://bitbucket.org/connectathon/sandbox-manager-v3/src/fix-order-sign-order-select-response/